### PR TITLE
Add step to free disk space on FC34 build

### DIFF
--- a/.github/workflows/build-acs-kernel.yml
+++ b/.github/workflows/build-acs-kernel.yml
@@ -40,6 +40,16 @@ jobs:
       - name: Checkout this repo
         uses: actions/checkout@v2
 
+      - name: Free up disk space
+        run: |
+          sudo apt-get -qq purge build-essential "ghc*"
+          sudo apt-get clean
+          # cleanup docker images not used by us
+          docker system prune -af
+          # free up a lot of stuff from /usr/local
+          sudo rm -rf /usr/local
+          df -h
+
       - name: Build the Fedora 34 RPMs
         id: build-rpms
         uses: ./fc34-action


### PR DESCRIPTION
FC34 builds now failing because the disk is filling up, [link](https://github.com/some-natalie/fedora-acs-override/actions/runs/1767640157).  Added the same step that fixed the problem in the FC35 build.