### PR TITLE
Add Missing Build Dependencies for F35 and F36

### DIFF
--- a/fc35-action/Dockerfile
+++ b/fc35-action/Dockerfile
@@ -12,8 +12,8 @@ RUN dnf update -y && dnf clean all
 # Install build dependencies
 RUN dnf install -y fedpkg fedora-packager rpmdevtools ncurses-devel pesign \
     bpftool bc bison dwarves elfutils-devel flex gcc gcc-c++ gcc-plugin-devel \
-    hostname m4 make net-tools openssl openssl-devel perl-devel \
-    perl-generators python3-devel \
+    glibc-static hostname m4 make net-tools openssl openssl-devel perl-devel \
+    perl-generators python3-devel which \
     && dnf clean all
 
 # Setup build directory

--- a/fc35-action/entrypoint.sh
+++ b/fc35-action/entrypoint.sh
@@ -10,7 +10,7 @@ koji download-build --arch=src kernel-"$(dnf list kernel | grep -Eo '[0-9]\.[0-9
 rpm -Uvh kernel-"$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+.fc[0-9][0-9]')".src.rpm
 
 # Install the build dependencies
-cd ~/rpmbuild/SPECS/ && dnf builddep kernel.spec
+cd ~/rpmbuild/SPECS/ && dnf builddep kernel.spec -y
 
 # Download the ACS override patch
 curl -o ~/rpmbuild/SOURCES/add-acs-override.patch https://raw.githubusercontent.com/some-natalie/fedora-acs-override/main/acs/add-acs-override.patch 

--- a/fc36-action/Dockerfile
+++ b/fc36-action/Dockerfile
@@ -12,8 +12,8 @@ RUN dnf update -y && dnf clean all
 # Install build dependencies
 RUN dnf install -y fedpkg fedora-packager rpmdevtools ncurses-devel pesign \
     bpftool bc bison dwarves elfutils-devel flex gcc gcc-c++ gcc-plugin-devel \
-    hostname m4 make net-tools openssl openssl-devel perl-devel \
-    perl-generators python3-devel \
+    glibc-static hostname m4 make net-tools openssl openssl-devel perl-devel \
+    perl-generators python3-devel which \
     && dnf clean all
 
 # Setup build directory

--- a/fc36-action/entrypoint.sh
+++ b/fc36-action/entrypoint.sh
@@ -10,7 +10,7 @@ koji download-build --arch=src kernel-"$(dnf list kernel | grep -Eo '[0-9]\.[0-9
 rpm -Uvh kernel-"$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+.fc[0-9][0-9]')".src.rpm
 
 # Install the build dependencies
-cd ~/rpmbuild/SPECS/ && dnf builddep kernel.spec
+cd ~/rpmbuild/SPECS/ && dnf builddep kernel.spec -y
 
 # Download the ACS override patch
 curl -o ~/rpmbuild/SOURCES/add-acs-override.patch https://raw.githubusercontent.com/some-natalie/fedora-acs-override/main/acs/add-acs-override.patch 


### PR DESCRIPTION
Hello, found a couple of changes when I was upgrading my kernel.

- Adds `glibc-static` and `which` as dependencies for f35 and f36 builds. 
- Allows dnf builddep to automatically install new deps when needed

Doesn't seem like the build fails on these unlike f34, but we should probably install them just in case.
You can see them [here](https://github.com/some-natalie/fedora-acs-override/runs/6638829309?check_suite_focus=true#step:4:2604)

I'm currently running a build on my fork, but considering these things take like 4 hours I figured I would get the PR up first.
https://github.com/evanjarrett/fedora-acs-override/runs/6646117058