### PR TITLE
Set output deprecation

### DIFF
--- a/fc35-action/entrypoint.sh
+++ b/fc35-action/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set environment variable
-echo "::set-output name=kernel-version::$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+')"
+echo "{kernel-version}={$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+')}" >> $GITHUB_OUTPUT
 
 # Download the latest kernel source RPM
 koji download-build --arch=src kernel-"$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+.fc[0-9][0-9]')".src.rpm

--- a/fc35-action/entrypoint.sh
+++ b/fc35-action/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set environment variable
-echo "{kernel-version}={$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+')}" >> $GITHUB_OUTPUT
+echo "kernel-version=$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+')" >> $GITHUB_OUTPUT
 
 # Download the latest kernel source RPM
 koji download-build --arch=src kernel-"$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+.fc[0-9][0-9]')".src.rpm

--- a/fc36-action/entrypoint.sh
+++ b/fc36-action/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set environment variable
-echo "::set-output name=kernel-version::$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+')"
+echo "{kernel-version}={$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+')}" >> $GITHUB_OUTPUT
 
 # Download the latest kernel source RPM
 koji download-build --arch=src kernel-"$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+.fc[0-9][0-9]')".src.rpm

--- a/fc36-action/entrypoint.sh
+++ b/fc36-action/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set environment variable
-echo "{kernel-version}={$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+')}" >> $GITHUB_OUTPUT
+echo "kernel-version=$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+')" >> $GITHUB_OUTPUT
 
 # Download the latest kernel source RPM
 koji download-build --arch=src kernel-"$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+.fc[0-9][0-9]')".src.rpm


### PR DESCRIPTION
The build action uses `set-output` to figure out what version of the kernel is being built and uploaded. 
 This is getting deprecated - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/