### PR TITLE
Fix F36 and F37 builds for kernel 6.1

### DIFF
--- a/acs/add-acs-override.patch
+++ b/acs/add-acs-override.patch
@@ -53,7 +53,7 @@ diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/adm
 index 20aac80..e625ef8 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
-@@ -3472,6 +3472,14 @@
+@@ -4162,6 +4162,14 @@
  		nomsi		[MSI] If the PCI_MSI kernel config parameter is
  				enabled, this kernel boot option can be used to
  				disable the use of MSI interrupts system-wide.
@@ -72,7 +72,7 @@ diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
 index ca9ed57..2a9bc81 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
-@@ -192,6 +192,107 @@ static int __init pci_apply_final_quirks(void)
+@@ -194,6 +194,107 @@ static int __init pci_apply_final_quirks(void)
  }
  fs_initcall_sync(pci_apply_final_quirks);
  
@@ -180,8 +180,8 @@ index ca9ed57..2a9bc81 100644
  /*
   * Decoding should be disabled for a PCI device during BAR sizing to avoid
   * conflict. But doing so may cause problems on host bridge and perhaps other
-@@ -4796,6 +4897,8 @@ static const struct pci_dev_acs_enabled {
- 	{ PCI_VENDOR_ID_ZHAOXIN, 0x9083, pci_quirk_mf_endpoint_acs },
+@@ -5004,6 +5106,8 @@ static const struct pci_dev_acs_enabled {
+ 	{ PCI_VENDOR_ID_NXP, 0x8d9b, pci_quirk_nxp_rp_acs },
  	/* Zhaoxin Root/Downstream Ports */
  	{ PCI_VENDOR_ID_ZHAOXIN, PCI_ANY_ID, pci_quirk_zhaoxin_pcie_ports_acs },
 +	/* allow acs for any */

--- a/fc37-action/Dockerfile
+++ b/fc37-action/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf update -y && dnf clean all
 RUN dnf install -y fedpkg fedora-packager rpmdevtools ncurses-devel pesign \
     bpftool bc bison dwarves elfutils-devel flex gcc gcc-c++ gcc-plugin-devel \
     glibc-static hostname m4 make net-tools openssl openssl-devel perl-devel \
-    perl-generators python3-devel which \
+    perl-generators python3-devel which kernel-rpm-macros \
     && dnf clean all
 
 # Setup build directory


### PR DESCRIPTION
I happened to check for new images since kernel 6.1 is out and noticed the build had failed.
I updated the patch file with the new line numbers.
Currently building new images on my fork https://github.com/evanjarrett/fedora-acs-override/actions/runs/4070983427
(since it takes 4 hours to complete, I didn't want to wait on this PR)

- add updated line numbers for patching kernel 6.1, 
- add kernel-rpm-macros as a required dependency for docker images
