### PR TITLE
Re-enable no debug no debuginfo while building to reduce build time

### DIFF
--- a/fc36-action/entrypoint.sh
+++ b/fc36-action/entrypoint.sh
@@ -21,4 +21,4 @@ sed -i '/^Patch1:*/a Patch1000: add-acs-override.patch' ~/rpmbuild/SPECS/kernel.
 sed -i '/^ApplyOptionalPatch patch-*/a ApplyOptionalPatch add-acs-override.patch' ~/rpmbuild/SPECS/kernel.spec
 
 # Build the things!
-cd ~/rpmbuild/SPECS && rpmbuild -bb kernel.spec --target x86_64 --nodeps
+cd ~/rpmbuild/SPECS && rpmbuild -bb kernel.spec --without debug --without debuginfo --target x86_64 --nodeps

--- a/fc37-action/entrypoint.sh
+++ b/fc37-action/entrypoint.sh
@@ -21,4 +21,4 @@ sed -i '/^Patch1:*/a Patch1000: add-acs-override.patch' ~/rpmbuild/SPECS/kernel.
 sed -i '/^ApplyOptionalPatch patch-*/a ApplyOptionalPatch add-acs-override.patch' ~/rpmbuild/SPECS/kernel.spec
 
 # Build the things!
-cd ~/rpmbuild/SPECS && rpmbuild -bb kernel.spec --target x86_64 --nodeps
+cd ~/rpmbuild/SPECS && rpmbuild -bb kernel.spec --without debug --without debuginfo --target x86_64 --nodeps


### PR DESCRIPTION
Hello again,
While troubleshooting the issue with the patch files, I had noticed that running without debug appeared to be working correctly again. I haven't dug into why, but we also never figured out why exactly it stopped working in the past.

This PR adds back in the parameters for removing debug and debuginfo from the build. This cuts the build time almost in half compared to building everything. It also appears to produce ever so slightly smaller files (an MB or 2 at most).
Current build from my fork here https://github.com/evanjarrett/fedora-acs-override/actions/runs/4080002541

The main concern with merging this is if it will ever break again and start creating larger files. I'm assuming that is not the intention and must have been a bug in the rpmbuild system.