### PR TITLE
Update add-acs-override.patch

### DIFF
--- a/acs/add-acs-override.patch
+++ b/acs/add-acs-override.patch
@@ -46,14 +46,14 @@ capability.  Please contact me to have your devices added and save
 your customers the hassle of this boot option.
 ---
  .../admin-guide/kernel-parameters.txt         |   8 ++
- drivers/pci/quirks.c                          | 103 ++++++++++++++++++
- 2 files changed, 111 insertions(+)
+ drivers/pci/quirks.c                          | 102 ++++++++++++++++++
+ 2 files changed, 110 insertions(+)
 
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index 20aac80..e625ef8 100644
+index 6cfa6e3996cf..fdbe34c0fbf3 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
-@@ -4162,6 +4162,14 @@
+@@ -4178,6 +4178,14 @@
  		nomsi		[MSI] If the PCI_MSI kernel config parameter is
  				enabled, this kernel boot option can be used to
  				disable the use of MSI interrupts system-wide.
@@ -69,10 +69,10 @@ index 20aac80..e625ef8 100644
  				Safety option to keep boot IRQs enabled. This
  				should never be necessary.
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index ca9ed57..2a9bc81 100644
+index 494fa46f5767..41150eb8bd4c 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
-@@ -194,6 +194,107 @@ static int __init pci_apply_final_quirks(void)
+@@ -194,6 +194,106 @@ static int __init pci_apply_final_quirks(void)
  }
  fs_initcall_sync(pci_apply_final_quirks);
  
@@ -176,18 +176,17 @@ index ca9ed57..2a9bc81 100644
 +	return -ENOTTY;
 +}
 +
-+
  /*
   * Decoding should be disabled for a PCI device during BAR sizing to avoid
   * conflict. But doing so may cause problems on host bridge and perhaps other
-@@ -5004,6 +5106,8 @@ static const struct pci_dev_acs_enabled {
- 	{ PCI_VENDOR_ID_NXP, 0x8d9b, pci_quirk_nxp_rp_acs },
- 	/* Zhaoxin Root/Downstream Ports */
+@@ -5002,6 +5102,8 @@ static const struct pci_dev_acs_enabled {
  	{ PCI_VENDOR_ID_ZHAOXIN, PCI_ANY_ID, pci_quirk_zhaoxin_pcie_ports_acs },
+ 	/* Wangxun nics */
+ 	{ PCI_VENDOR_ID_WANGXUN, PCI_ANY_ID, pci_quirk_wangxun_nic_acs },
 +	/* allow acs for any */
 +	{ PCI_ANY_ID, PCI_ANY_ID, pcie_acs_overrides },
  	{ 0 }
  };
  
 -- 
-2.26.2
+2.39.2


### PR DESCRIPTION
should work with 6.2