### PR TITLE
Rename the spec file to match the renamed package

### DIFF
--- a/fc43-action/entrypoint.sh
+++ b/fc43-action/entrypoint.sh
@@ -29,9 +29,14 @@ sed -i '/^Patch1:*/a Patch1000: add-acs-override.patch' ~/rpmbuild/SPECS/kernel.
 sed -i '/^ApplyOptionalPatch patch-*/a ApplyOptionalPatch add-acs-override.patch' ~/rpmbuild/SPECS/kernel.spec
 sed -i 's|cp ./bpf/tools/sbin/bpftool %{buildroot}%{_libexecdir}/kselftests/bpf/bpftool|cp /usr/bin/bpftool %{buildroot}%{_libexecdir}/kselftests/bpf/bpftool|' ~/rpmbuild/SPECS/kernel.spec
 
+# %prep checks each patch is declared by grepping ${RPM_PACKAGE_NAME}.spec, so
+# the file has to follow the package rename or it rejects the ACS patch as
+# undeclared. It hides the missing-file error, so the message blames the patch.
+mv ~/rpmbuild/SPECS/kernel.spec ~/rpmbuild/SPECS/kernel-acs.spec
+
 # Build the things!
 # perf, libperf and tools are dropped because they're named absolutely
 # (%package -n perf) rather than off %{name}, so the rename misses them and they
 # would collide with Fedora's. rtla and rv are inside the tools conditional.
-cd ~/rpmbuild/SPECS && rpmbuild -bb kernel.spec --without debug --without debuginfo \
+cd ~/rpmbuild/SPECS && rpmbuild -bb kernel-acs.spec --without debug --without debuginfo \
   --without perf --without libperf --without tools --target x86_64 --nodeps

--- a/fc44-action/entrypoint.sh
+++ b/fc44-action/entrypoint.sh
@@ -29,9 +29,14 @@ sed -i '/^Patch1:*/a Patch1000: add-acs-override.patch' ~/rpmbuild/SPECS/kernel.
 sed -i '/^ApplyOptionalPatch patch-*/a ApplyOptionalPatch add-acs-override.patch' ~/rpmbuild/SPECS/kernel.spec
 sed -i 's|cp ./bpf/tools/sbin/bpftool %{buildroot}%{_libexecdir}/kselftests/bpf/bpftool|cp /usr/bin/bpftool %{buildroot}%{_libexecdir}/kselftests/bpf/bpftool|' ~/rpmbuild/SPECS/kernel.spec
 
+# %prep checks each patch is declared by grepping ${RPM_PACKAGE_NAME}.spec, so
+# the file has to follow the package rename or it rejects the ACS patch as
+# undeclared. It hides the missing-file error, so the message blames the patch.
+mv ~/rpmbuild/SPECS/kernel.spec ~/rpmbuild/SPECS/kernel-acs.spec
+
 # Build the things!
 # perf, libperf and tools are dropped because they're named absolutely
 # (%package -n perf) rather than off %{name}, so the rename misses them and they
 # would collide with Fedora's. rtla and rv are inside the tools conditional.
-cd ~/rpmbuild/SPECS && rpmbuild -bb kernel.spec --without debug --without debuginfo \
+cd ~/rpmbuild/SPECS && rpmbuild -bb kernel-acs.spec --without debug --without debuginfo \
   --without perf --without libperf --without tools --target x86_64 --nodeps


### PR DESCRIPTION
## Summary

Fixes the post-merge build failure on `main` (`kernel.spec:: ERROR: Patch add-acs-override.patch not listed as a source patch in specfile`).

`%prep` checks that every patch it applies is declared, by grepping `%{_specdir}/${RPM_PACKAGE_NAME}.spec`. Renaming the package family to `kernel-acs` made that path `~/rpmbuild/SPECS/kernel-acs.spec`, but the file on disk was still `kernel.spec`. The grep's stderr is redirected to `/dev/null`, so the missing file surfaced as "patch not declared" rather than "no such file".

Renames the spec file after the seds run and builds from the new name. `dnf builddep` still runs against `kernel.spec`, before the rename.

## Test plan

- [ ] `build-acs-kernel.yml` reaches `%build` for both fc43 and fc44
- [ ] Built RPMs are named `kernel-acs*`