### PR TITLE
Rename the config sources to match the renamed package

### DIFF
--- a/fc43-action/entrypoint.sh
+++ b/fc43-action/entrypoint.sh
@@ -34,6 +34,13 @@ sed -i 's|cp ./bpf/tools/sbin/bpftool %{buildroot}%{_libexecdir}/kselftests/bpf/
 # undeclared. It hides the missing-file error, so the message blames the patch.
 mv ~/rpmbuild/SPECS/kernel.spec ~/rpmbuild/SPECS/kernel-acs.spec
 
+# The config and changelog sources are named off %{name} too, so they follow the
+# rename as well - %prep copies them by glob and fails if none match.
+cd ~/rpmbuild/SOURCES || exit 1
+for f in kernel-*.config kernel.changelog; do
+  [ -e "$f" ] && mv "$f" "kernel-acs${f#kernel}"
+done
+
 # Build the things!
 # perf, libperf and tools are dropped because they're named absolutely
 # (%package -n perf) rather than off %{name}, so the rename misses them and they

--- a/fc44-action/entrypoint.sh
+++ b/fc44-action/entrypoint.sh
@@ -34,6 +34,13 @@ sed -i 's|cp ./bpf/tools/sbin/bpftool %{buildroot}%{_libexecdir}/kselftests/bpf/
 # undeclared. It hides the missing-file error, so the message blames the patch.
 mv ~/rpmbuild/SPECS/kernel.spec ~/rpmbuild/SPECS/kernel-acs.spec
 
+# The config and changelog sources are named off %{name} too, so they follow the
+# rename as well - %prep copies them by glob and fails if none match.
+cd ~/rpmbuild/SOURCES || exit 1
+for f in kernel-*.config kernel.changelog; do
+  [ -e "$f" ] && mv "$f" "kernel-acs${f#kernel}"
+done
+
 # Build the things!
 # perf, libperf and tools are dropped because they're named absolutely
 # (%package -n perf) rather than off %{name}, so the rename misses them and they


### PR DESCRIPTION
## Summary

Second half of the `kernel-acs` rename fallout. `%prep` failed with `cp: cannot stat '/github/home/rpmbuild/SOURCES/kernel-acs-*.config': No such file or directory`.

The kernel configs (`Source24`…`Source701`) and the changelog (`Source2`) are declared as `%{name}-*.config` and `%{name}.changelog`, so renaming the package family pointed them at `kernel-acs-*` names while the SRPM ships them as `kernel-*`. `%prep` copies the configs with a glob, so a zero-match glob is a hard failure. Renaming the files in `SOURCES` alongside the spec file fixes both, and `generate_all_configs.sh` already takes the package name as `SPECPACKAGE_NAME`, so the generated configs follow.

`%{name}-*.config` and `%{name}.changelog` are the only `%{name}`-derived source filenames in the spec.

## Test plan

- [x] `%prep` runs to completion in a `fedora:44` container with this change (`rpmbuild -bp`, exit 0, configs generated as `kernel-acs-7.1.9-x86_64.config`)
- [ ] `build-acs-kernel.yml` gets past `%prep` for both fc43 and fc44
- [ ] Built RPMs are named `kernel-acs*`