### PR TITLE
Publish the fresh RPMs when only one Fedora version builds

### DIFF
--- a/.github/scripts/publish-yum-repo.sh
+++ b/.github/scripts/publish-yum-repo.sh
@@ -100,7 +100,13 @@ for fc in $fcs; do
       mkdir -p "$dir"
       gh release download "$tag" --repo "$REPO" --dir "$dir" --pattern '*.rpm'
     fi
-    if rpm --checksig "$dir"/*.rpm | grep -v 'signatures OK'; then
+    # sudo, because --import above wrote the key into root's keyring and an
+    # unprivileged --checksig reports every package NOKEY.  Collected rather than
+    # piped into `if`, because pipefail makes the condition read rpm's nonzero exit
+    # instead of grep's match, which is exactly backwards.
+    unsigned=$(sudo rpm --checksig "$dir"/*.rpm | grep -v 'signatures OK' || true)
+    if [ -n "$unsigned" ]; then
+      printf '%s\n' "$unsigned"
       echo "::error::the RPMs above are unsigned, refusing to publish"
       exit 1
     fi

--- a/.github/workflows/build-acs-kernel.yml
+++ b/.github/workflows/build-acs-kernel.yml
@@ -138,11 +138,22 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Collect the freshly built RPMs
+      # downloaded by name into a fixed path, because a pattern download flattens
+      # into path/ instead of path/<artifact> whenever only one artifact matches,
+      # and then the publish script finds no fresh RPMs for the version that built
+      - name: Collect the freshly built Fedora 43 RPMs
+        if: needs.build-fc43.result == 'success'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: fresh
-          pattern: rpms-fc*
+          name: rpms-fc43
+          path: fresh/rpms-fc43
+
+      - name: Collect the freshly built Fedora 44 RPMs
+        if: needs.build-fc44.result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: rpms-fc44
+          path: fresh/rpms-fc44
 
       - name: Install the signing and indexing tools
         run: sudo apt-get update -qq && sudo apt-get install -y -qq rpm createrepo-c


### PR DESCRIPTION
## Summary

Run [32853234588](https://github.com/some-natalie/fedora-acs-override/actions/runs/32853234588) built fc44 for two hours, then published nothing. Two bugs.

**The fresh RPMs were never found.** `download-artifact` extracts into `path/` instead of `path/<artifact-name>` when exactly one artifact matches the pattern (`artifacts.length === 1` in its path resolution), and no input overrides that. fc43 was up to date, so only `rpms-fc44` matched, the RPMs landed in `fresh/` instead of `fresh/rpms-fc44/`, and `publish-yum-repo.sh` skipped its publish block — silently, since indexing the existing releases still succeeds. It worked whenever both versions built. Downloading each artifact by name into a fixed path pins the layout.

**The unsigned-RPM guard never fired.** `if rpm --checksig "$dir"/*.rpm | grep -v 'signatures OK'` is inverted under `set -o pipefail`: when a package fails its check, rpm exits nonzero, pipefail hands that to the `if`, and the branch is skipped even though grep matched. On top of that the unprivileged `--checksig` reported every package `NOKEY`, because `rpm --import` runs under `sudo` and writes to root's keyring. So the run printed `digests SIGNATURES NOT OK` for all 100-odd published RPMs and carried on. Both fixed: `sudo rpm --checksig`, and the output collected instead of piped into the condition.

The published RPMs themselves are fine — signed with `d9500e334c48dd8b`, and `rpm --checksig` reports `digests signatures OK` once the key is visible.

## Test plan

- [x] `ubuntu:24.04` + rpm 4.18.2, root-imported key: unprivileged `--checksig` → `SIGNATURES NOT OK` exit 1; `sudo --checksig` → `digests signatures OK` exit 0
- [x] the rewritten guard passes on a signed RPM and exits 1 on the same RPM after `rpm --delsign`
- [x] `actionlint`, `zizmor`, `shellcheck`, `shfmt` clean
- [ ] a run where only one Fedora version builds publishes its release