### PR TITLE
Copy the ACS patch from the checkout instead of downloading it

### DIFF
--- a/fc43-action/entrypoint.sh
+++ b/fc43-action/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Set environment variable
 echo "kernel-version=$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+')" >>"$GITHUB_OUTPUT"
@@ -12,8 +13,10 @@ rpm -Uvh kernel-"$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+.fc[0
 # Install the build dependencies
 cd ~/rpmbuild/SPECS/ && dnf builddep kernel.spec -y
 
-# Download the ACS override patch
-curl -o ~/rpmbuild/SOURCES/add-acs-override.patch https://raw.githubusercontent.com/some-natalie/fedora-acs-override/main/acs/add-acs-override.patch
+# Take the ACS override patch from the checkout, not the network - fetching it
+# from raw.githubusercontent.com flakes, and pinning to main meant PR builds
+# never tested the PR's own patch.
+cp "$GITHUB_WORKSPACE/acs/add-acs-override.patch" ~/rpmbuild/SOURCES/add-acs-override.patch
 
 # Edit the spec file with some sed magics
 # Rename the whole family to kernel-acs - every subpackage is named off %{name}.

--- a/fc44-action/entrypoint.sh
+++ b/fc44-action/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Set environment variable
 echo "kernel-version=$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+')" >>"$GITHUB_OUTPUT"
@@ -12,8 +13,10 @@ rpm -Uvh kernel-"$(dnf list kernel | grep -Eo '[0-9]\.[0-9]+\.[0-9]+-[0-9]+.fc[0
 # Install the build dependencies
 cd ~/rpmbuild/SPECS/ && dnf builddep kernel.spec -y
 
-# Download the ACS override patch
-curl -o ~/rpmbuild/SOURCES/add-acs-override.patch https://raw.githubusercontent.com/some-natalie/fedora-acs-override/main/acs/add-acs-override.patch
+# Take the ACS override patch from the checkout, not the network - fetching it
+# from raw.githubusercontent.com flakes, and pinning to main meant PR builds
+# never tested the PR's own patch.
+cp "$GITHUB_WORKSPACE/acs/add-acs-override.patch" ~/rpmbuild/SOURCES/add-acs-override.patch
 
 # Edit the spec file with some sed magics
 # Rename the whole family to kernel-acs - every subpackage is named off %{name}.


### PR DESCRIPTION
## What broke

The nightly fc43 build ([run 32934812682](https://github.com/some-natalie/fedora-acs-override/actions/runs/32934812682/job/98074036848)) failed with:

```
kernel.spec:: ERROR: Patch add-acs-override.patch listed in specfile but is missing
error: Bad exit status from /var/tmp/rpm-tmp.jytDZS (%prep)
```

The patch wasn't missing from the spec file — it was never downloaded. A minute earlier in the same log:

```
curl: (35) Recv failure: Connection reset by peer
```

`entrypoint.sh` had no `set -e`, so the failed download didn't stop the script. Everything after it ran against a `~/rpmbuild/SOURCES` that had no patch in it, and the first thing to notice was rpmbuild's `%prep` sanity check — which reports the file as undeclared, pointing at the spec file rather than the download.

## What changed

- Copy `acs/add-acs-override.patch` from `$GITHUB_WORKSPACE` instead of fetching it over the network. Both of these are local Docker actions (`uses: ./fc43-action`), so the checkout is already mounted in the container.
- Add `set -euo pipefail` so a failure stops the script where it happens.

Both entrypoints were byte-identical, so fc44 carried the same latent failure and gets the same change.

Dropping the download also means a PR build tests the patch from that PR. The old URL was pinned to `main`, so a change to `acs/add-acs-override.patch` was never exercised by CI until after it merged.

The `curl` in the README is the manual build-it-yourself path, where there's no checkout to copy from. Left as is.

## Test plan

- [x] `shellcheck` clean on both scripts
- [x] `bash -n` parses both
- [x] Exec bits intact, scripts still byte-identical to each other
- [ ] Re-run the build workflow and confirm fc43 gets past `%prep` (fc43 is still behind at 7.1.9-100.fc43 vs upstream 7.1.10-100.fc43)