### PR TITLE
Clear the draft a failed publish leaves behind

### DIFF
--- a/.github/scripts/publish-yum-repo.sh
+++ b/.github/scripts/publish-yum-repo.sh
@@ -95,6 +95,10 @@ for fc in $fcs; do
         printf 'PUBLISHED_FC%s=%s\n' "$fc" "$work/$tag" >>"${GITHUB_ENV:-/dev/null}"
         releases=$(printf '%s\n%s' "$releases" "$tag")
       else
+        # the failed publish leaves its draft behind, and a stray draft is what
+        # stalls this pipeline in the first place - clear it rather than leaving
+        # one to be found later
+        gh release delete "$tag" --repo "$REPO" --yes 2>/dev/null || true
         # left out of $releases on purpose: an unpublished release's assets 404 for
         # everyone but this token, and indexing them hands dnf URLs it can't fetch
         echo "::warning::could not publish ${tag}, leaving it out of the repo - a deleted release burns its tag name for good"


### PR DESCRIPTION
## Summary

Follow-up to #454. [Run 33072097655](https://github.com/some-natalie/fedora-acs-override/actions/runs/33072097655) warned and skipped `7.1.10-100.fc43` as intended, and the deployed fc43 repodata now lists only 7.1.8 and 7.1.9 - but it still left a draft behind (`untagged-3d2cc00a0b4175964b5a`).

`gh release create --draft` succeeds even when the tag name is burned; only the publish 422s. So the unpublishable version leaves a draft carrying ~150MB of assets, and the daily run deletes and recreates it. It's kept out of the index, so nothing breaks, but a stray draft is exactly what stalled this pipeline for three days.

Delete the release on the failure path.

The leftover-draft branch above it stays - it's still the recovery path for a run cancelled between `create` and `edit`.

## Test plan

- [x] `shellcheck` and `shfmt -i 2 -d` clean
- [ ] next scheduled run leaves no draft in `gh release list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)